### PR TITLE
Fixed typo in format command

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -22,4 +22,4 @@ jobs:
     - name: Run Clippy
       run: cargo clippy
     - name: Format
-      run: cargo format
+      run: cargo fmt


### PR DESCRIPTION
Fixed '''cargo format''' to '''cargo fmt'''